### PR TITLE
feat: Determine output file name based on input file path

### DIFF
--- a/cmd/gliffy.go
+++ b/cmd/gliffy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ var gliffyCmd = &cobra.Command{
 		}
 
 		if strings.HasPrefix(exportPath, defaultOutputPath) {
-			exportPath = strings.TrimSuffix(path.Base(importPath), ".excalidraw") + ".gliffy"
+			exportPath = strings.TrimSuffix(path.Base(importPath), filepath.Ext(importPath)) + ".gliffy"
 		}
 
 		err := conv.ConvertExcalidrawToGliffy(importPath, exportPath)

--- a/cmd/gliffy.go
+++ b/cmd/gliffy.go
@@ -4,9 +4,13 @@ import (
 	conv "diagram-converter/internal/conversion"
 	"fmt"
 	"os"
+	"path"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+var defaultOutputPath = "your_file.gliffy"
 
 var gliffyCmd = &cobra.Command{
 	Use:   "gliffy",
@@ -19,6 +23,10 @@ var gliffyCmd = &cobra.Command{
 		if len(importPath) == 0 {
 			fmt.Fprintf(os.Stderr, "Input file path not provided. (Use --help for details.)\n")
 			os.Exit(1)
+		}
+
+		if strings.HasPrefix(exportPath, defaultOutputPath) {
+			exportPath = strings.TrimSuffix(path.Base(importPath), ".excalidraw") + ".gliffy"
 		}
 
 		err := conv.ConvertExcalidrawToGliffy(importPath, exportPath)
@@ -34,5 +42,5 @@ func init() {
 	rootCmd.AddCommand(gliffyCmd)
 
 	gliffyCmd.PersistentFlags().StringP("input", "i", "", "input file path")
-	gliffyCmd.PersistentFlags().StringP("output", "o", "output.gliffy", "output file path")
+	gliffyCmd.PersistentFlags().StringP("output", "o", defaultOutputPath, "output file path")
 }


### PR DESCRIPTION
If an output path is not provided, determine the output file name based on the input file path.

* The output file extension will be replaced by `.gliffy`.
* The output file will be saved where executed - not in the input path.

**Example behavior:**
`foo.excalidraw` -> `foo.gliffy`
`foo.bar` -> `foo.gliffy`
`foobar/foo.excalidraw` -> `foo.gliffy`