### PR TITLE
feat: Default to printing help when arguments not provided

### DIFF
--- a/cmd/gliffy.go
+++ b/cmd/gliffy.go
@@ -16,13 +16,23 @@ var defaultOutputPath = "your_file.gliffy"
 var gliffyCmd = &cobra.Command{
 	Use:   "gliffy",
 	Short: "Convert an Excalidraw diagram to Gliffy format",
-	Long:  `Use this command to convert an Excalidraw diagram to the Gliffy format.`,
+	Long: `This command is used to convert an Excalidraw diagram to the Gliffy format.
+
+  When an output file path is not provided, it will be determined 
+automatically based on the filename of the input file. I.e. the 
+input file path './subfolder/your_file.excalidraw' will produce 
+the default output file path './your_file.gliffy'.
+
+Example:
+  exconv gliffy -i your_file.excalidraw
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		importPath, _ := cmd.Flags().GetString("input")
 		exportPath, _ := cmd.Flags().GetString("output")
 
 		if len(importPath) == 0 {
-			fmt.Fprintf(os.Stderr, "Input file path not provided. (Use --help for details.)\n")
+			fmt.Fprintf(os.Stderr, "Error: Input file path not provided.\n\n")
+			cmd.Help()
 			os.Exit(1)
 		}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,7 +14,7 @@ var (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Output the application version",
-	Long:  `Provides information about the release version and the Git commit it was built from.`,
+	Long:  `This command provides information about the release version and the Git commit it was built from.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("v%s (%s)\n", version, string(commit[0:7]))
 	},


### PR DESCRIPTION
Minor UX improvements. 

* Instead of suggesting the use of the help command when expected arguments are not provided, the output of the help command is printed automatically.
* Adds information about how the output path is now auto-determined, as well as an example command.