### PR TITLE
fix: Accept strokeWidth as float, cast to int

### DIFF
--- a/internal/conversion/gliffy.go
+++ b/internal/conversion/gliffy.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -165,7 +166,7 @@ func AddElements(addChildren bool, input datastr.ExcalidrawScene, objects []data
 			shape.DashStyle = StrokeStyleConvExcGliffy(element.StrokeStyle)
 			shape.FillColor = FillColorConvExcGliffy(element.BackgroundColor)
 			shape.StrokeColor = element.StrokeColor
-			shape.StrokeWidth = int64(element.StrokeWidth)
+			shape.StrokeWidth = int64(math.Round(element.StrokeWidth))
 			shape.Opacity = element.Opacity * 0.01
 
 			if element.FillStyle != "solid" {
@@ -208,7 +209,7 @@ func AddElements(addChildren bool, input datastr.ExcalidrawScene, objects []data
 
 				line.DashStyle = StrokeStyleConvExcGliffy(element.StrokeStyle)
 				line.StrokeColor = element.StrokeColor
-				line.StrokeWidth = int64(element.StrokeWidth)
+				line.StrokeWidth = int64(math.Round(element.StrokeWidth))
 				line.FillColor = "none"
 				line.StartArrowRotation = "auto"
 				line.EndArrowRotation = "auto"

--- a/internal/conversion/gliffy.go
+++ b/internal/conversion/gliffy.go
@@ -165,7 +165,7 @@ func AddElements(addChildren bool, input datastr.ExcalidrawScene, objects []data
 			shape.DashStyle = StrokeStyleConvExcGliffy(element.StrokeStyle)
 			shape.FillColor = FillColorConvExcGliffy(element.BackgroundColor)
 			shape.StrokeColor = element.StrokeColor
-			shape.StrokeWidth = element.StrokeWidth
+			shape.StrokeWidth = int64(element.StrokeWidth)
 			shape.Opacity = element.Opacity * 0.01
 
 			if element.FillStyle != "solid" {
@@ -208,7 +208,7 @@ func AddElements(addChildren bool, input datastr.ExcalidrawScene, objects []data
 
 				line.DashStyle = StrokeStyleConvExcGliffy(element.StrokeStyle)
 				line.StrokeColor = element.StrokeColor
-				line.StrokeWidth = element.StrokeWidth
+				line.StrokeWidth = int64(element.StrokeWidth)
 				line.FillColor = "none"
 				line.StartArrowRotation = "auto"
 				line.EndArrowRotation = "auto"

--- a/internal/datastructures/excalidraw.go
+++ b/internal/datastructures/excalidraw.go
@@ -30,7 +30,7 @@ type ExcalidrawScene struct {
 		StrokeColor     string  `json:"strokeColor"`
 		StrokeSharpness string  `json:"strokeSharpness"`
 		StrokeStyle     string  `json:"strokeStyle"`
-		StrokeWidth     int64   `json:"strokeWidth"`
+		StrokeWidth     float64 `json:"strokeWidth"`
 		Text            string  `json:"text"`
 		TextAlign       string  `json:"textAlign"`
 		Type            string  `json:"type"`


### PR DESCRIPTION
Accepts .excalidraw `strokeWidth` as float, cast to int and rounded.

Example:
* strokeWidth 0.5 -> 1
* strokeWidth 1.5 -> 2

Fixes one of the issues in #27 .