### PR TITLE
feat: Add version check that outputs whether the installed version is the latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Install dependencies
         run: go mod download
       - name: Test with the Go CLI
-        run: go test -v ./cmd
+        run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ go mod download
 
 ### Run tests
 ```shell
-go test -v ./cmd
+go test -v ./...
 ```
 
 ### Compile and run

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	internal "diagram-converter/internal"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -10,8 +11,8 @@ import (
 var (
 	version        = "dev"
 	commit         = "nnnnnnn"
-	gitHubRepoUser = "sindrel"
-	gitHubRepoName = "excalidraw-converter"
+	githubRepoUser = "sindrel"
+	githubRepoName = "excalidraw-converter"
 	noVersionCheck bool
 )
 
@@ -23,7 +24,11 @@ var versionCmd = &cobra.Command{
 		fmt.Printf("v%s (%s)\n", version, string(commit[0:7]))
 
 		if !noVersionCheck {
-			internal.PrintVersionCheck(gitHubRepoUser, gitHubRepoName, version)
+			err := internal.PrintVersionCheck(githubRepoUser, githubRepoName, version)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to check for latest version: %s\n", err)
+				os.Exit(1)
+			}
 		}
 	},
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,14 +1,18 @@
 package cmd
 
 import (
+	internal "diagram-converter/internal"
 	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	version = "dev"
-	commit  = "nnnnnnn"
+	version        = "dev"
+	commit         = "nnnnnnn"
+	gitHubRepoUser = "sindrel"
+	gitHubRepoName = "excalidraw-converter"
+	noVersionCheck bool
 )
 
 var versionCmd = &cobra.Command{
@@ -17,9 +21,15 @@ var versionCmd = &cobra.Command{
 	Long:  `This command provides information about the release version and the Git commit it was built from.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("v%s (%s)\n", version, string(commit[0:7]))
+
+		if !noVersionCheck {
+			internal.PrintVersionCheck(gitHubRepoUser, gitHubRepoName, version)
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+
+	versionCmd.Flags().BoolVar(&noVersionCheck, "no-check", false, "opt-out from checking for latest version")
 }

--- a/internal/datastructures/internals.go
+++ b/internal/datastructures/internals.go
@@ -26,3 +26,7 @@ type GraphicTypes struct {
 		Gliffy     []string `json:"gliffy"`
 	} `json:"image"`
 }
+
+type GitHubRelease struct {
+	TagName string `json:"tag_name"`
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -3,6 +3,7 @@ package internal
 import (
 	datastr "diagram-converter/internal/datastructures"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -36,6 +37,10 @@ func CheckIfLatestVersion(user, repo, version string) (bool, string, error) {
 		return false, "", err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return false, "", errors.New("could not fetch releases")
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,8 +1,12 @@
 package internal
 
 import (
+	datastr "diagram-converter/internal/datastructures"
+	"encoding/json"
+	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"os"
 )
 
@@ -22,4 +26,42 @@ func WriteToFile(filename string, data string) error {
 
 func NormalizeRotation(angle float64) float64 {
 	return (angle * 180) / math.Pi
+}
+
+func CheckIfLatestVersion(user, repo, version string) (bool, string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", user, repo)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return false, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", err
+	}
+
+	var release datastr.GitHubRelease
+	err = json.Unmarshal(body, &release)
+	if err != nil {
+		return false, "", err
+	}
+
+	return release.TagName == version, release.TagName, nil
+}
+
+func PrintVersionCheck(user, repo, version string) error {
+	isLatest, latest, err := CheckIfLatestVersion(user, repo, version)
+	if err != nil {
+		return err
+	}
+
+	if !isLatest {
+		fmt.Printf("\nA newer version is available (%s). Go to 'https://github.com/%s/%s/releases' to download the latest version.\n", latest, user, repo)
+	} else {
+		fmt.Printf("\nYou are using the latest version.\n")
+	}
+
+	return nil
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,20 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	version        = "v0.0.1"
+	gitHubRepoUser = "sindrel"
+	gitHubRepoName = "excalidraw-converter"
+)
+
+func TestCheckIfLatestVersion(t *testing.T) {
+	isLatest, _, err := CheckIfLatestVersion(gitHubRepoUser, gitHubRepoName, version)
+
+	assert.Nil(t, err)
+	assert.Equal(t, isLatest, false)
+}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -8,12 +8,12 @@ import (
 
 var (
 	version        = "v0.0.1"
-	gitHubRepoUser = "sindrel"
-	gitHubRepoName = "excalidraw-converter"
+	githubRepoUser = "sindrel"
+	githubRepoName = "excalidraw-converter"
 )
 
 func TestCheckIfLatestVersion(t *testing.T) {
-	isLatest, _, err := CheckIfLatestVersion(gitHubRepoUser, gitHubRepoName, version)
+	isLatest, _, err := CheckIfLatestVersion(githubRepoUser, githubRepoName, version)
 
 	assert.Nil(t, err)
 	assert.Equal(t, isLatest, false)


### PR DESCRIPTION
- When the command `exconv version` is run, it will check whether the installed version is the latest available release.
- The optional flag `--no-check` allows for opting out of the version check.

The check is done by comparing the installed version to the latest stable GitHub release.