### PR TITLE
fix: Refactor gliffy conversion; separate conversion and file output

### DIFF
--- a/cmd/gliffy.go
+++ b/cmd/gliffy.go
@@ -40,7 +40,7 @@ Example:
 			exportPath = strings.TrimSuffix(path.Base(importPath), filepath.Ext(importPath)) + ".gliffy"
 		}
 
-		err := conv.ConvertExcalidrawToGliffy(importPath, exportPath)
+		err := conv.ConvertExcalidrawToGliffyFile(importPath, exportPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to convert Excalidraw diagram to Gliffy diagram: %s\n", err)
 			os.Exit(1)

--- a/cmd/gliffy_test.go
+++ b/cmd/gliffy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConvertExcalidrawToGliffy(t *testing.T) {
+func TestConvertExcalidrawToGliffyFile(t *testing.T) {
 	inputDataPath := "../test/data/test_input.excalidraw"
 	outputDataPath := "../test/data/test_output.gliffy.tmp"
 	expectedDataPath := "../test/data/test_output.gliffy"

--- a/cmd/gliffy_test.go
+++ b/cmd/gliffy_test.go
@@ -16,7 +16,7 @@ func TestConvertExcalidrawToGliffy(t *testing.T) {
 	outputDataPath := "../test/data/test_output.gliffy.tmp"
 	expectedDataPath := "../test/data/test_output.gliffy"
 
-	err := conv.ConvertExcalidrawToGliffy(inputDataPath, outputDataPath)
+	err := conv.ConvertExcalidrawToGliffyFile(inputDataPath, outputDataPath)
 	assert.Nil(t, err)
 
 	outputData, err := os.ReadFile(outputDataPath)

--- a/internal/conversion/gliffy.go
+++ b/internal/conversion/gliffy.go
@@ -61,14 +61,12 @@ func ConvertExcalidrawToGliffy(data string) (string, error) {
 
 	objects, objectIDs, err = AddElements(false, input, objects, objectIDs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to add element(s): %s\n", err)
-		os.Exit(1)
+		return "", errors.New("Unable to add element(s): " + err.Error())
 	}
 
 	objects, _, err = AddElements(true, input, objects, objectIDs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to add element(s) with parent(s): %s\n", err)
-		os.Exit(1)
+		return "", errors.New("Unable to add element(s) with parent(s): " + err.Error())
 	}
 
 	priorityGraphics := []string{

--- a/internal/conversion/gliffy.go
+++ b/internal/conversion/gliffy.go
@@ -33,7 +33,7 @@ func ConvertExcalidrawToGliffyFile(importPath string, exportPath string) error {
 
 	err = internal.WriteToFile(exportPath, string(output))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Saving diagram failed. %s", err)
+		fmt.Fprintf(os.Stderr, "Saving diagram failed. %s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
These changes are only changes to the code structure, no functional changes.

- File IO has been extracted from the main function `ConvertExcalidrawToGliffy`, and is now handled by the new wrapper function `ConvertExcalidrawToGliffyFile`.
- This slims down the main function, and makes it easier to unit test.