### PR TITLE
fix: Add padding to canvas placement offset to avoid clipping

### DIFF
--- a/internal/conversion/gliffy.go
+++ b/internal/conversion/gliffy.go
@@ -445,6 +445,9 @@ func GetXYOffset(input datastr.ExcalidrawScene) (float64, float64) {
 		}
 	}
 
+	xMin -= 10
+	yMin -= 10
+
 	fmt.Printf("  Canvas Offset X: %f, Offset Y: %f\n", xMin, yMin)
 
 	return xMin, yMin

--- a/test/data/test_output.gliffy
+++ b/test/data/test_output.gliffy
@@ -63,7 +63,7 @@
     "autosaveDisabled": false,
     "editorVersion": null,
     "exportBorder": false,
-    "lastSerialized": 1707931162256,
+    "lastSerialized": 1707932100344,
     "libraries": [
       "com.gliffy.libraries.basic.basic_v1.default",
       "com.gliffy.libraries.flowchart.flowchart_v1.default"
@@ -124,8 +124,8 @@
         "rotation": 355.17923392190727,
         "uid": "com.gliffy.shape.basic.basic_v1.default.round_rectangle",
         "width": 186,
-        "x": 297.22,
-        "y": 162.5
+        "x": 307.22,
+        "y": 172.5
       },
       {
         "children": null,
@@ -156,8 +156,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.ellipse",
         "width": 151,
-        "x": 327.22,
-        "y": 371
+        "x": 337.22,
+        "y": 381
       },
       {
         "children": null,
@@ -188,8 +188,8 @@
         "rotation": 2.5733594631768173,
         "uid": "com.gliffy.shape.flowchart.flowchart_v1.default.decision",
         "width": 146,
-        "x": 139.22000000000003,
-        "y": 409
+        "x": 149.22000000000003,
+        "y": 419
       },
       {
         "children": null,
@@ -232,8 +232,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.line",
         "width": 317,
-        "x": 645.22,
-        "y": 94
+        "x": 655.22,
+        "y": 104
       },
       {
         "children": null,
@@ -276,8 +276,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.line",
         "width": 179,
-        "x": 487.22,
-        "y": 59
+        "x": 497.22,
+        "y": 69
       },
       {
         "children": null,
@@ -313,8 +313,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.text",
         "width": 487.5599853515625,
-        "x": 2.2200000000000273,
-        "y": 0
+        "x": 12.220000000000027,
+        "y": 10
       },
       {
         "children": null,
@@ -350,8 +350,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.text",
         "width": 444.24001464843747,
-        "x": 0.11999389648440228,
-        "y": 67
+        "x": 10.119993896484402,
+        "y": 77
       },
       {
         "children": null,
@@ -387,8 +387,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.text",
         "width": 313.2,
-        "x": 0,
-        "y": 128.5
+        "x": 10,
+        "y": 138.5
       },
       {
         "children": null,
@@ -419,8 +419,8 @@
         "rotation": 2.5733594631768173,
         "uid": "com.gliffy.shape.flowchart.flowchart_v1.default.decision",
         "width": 146,
-        "x": 146.2199999999999,
-        "y": 460.9999999999999
+        "x": 156.2199999999999,
+        "y": 470.9999999999999
       },
       {
         "children": null,
@@ -451,8 +451,8 @@
         "rotation": 7.314175428315577,
         "uid": "com.gliffy.shape.basic.basic_v1.default.rectangle",
         "width": 186,
-        "x": 247.22000000000003,
-        "y": 204.5
+        "x": 257.22,
+        "y": 214.5
       },
       {
         "children": null,
@@ -483,8 +483,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.ellipse",
         "width": 151,
-        "x": 507.72,
-        "y": 389
+        "x": 517.72,
+        "y": 399
       },
       {
         "children": null,
@@ -515,8 +515,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.ellipse",
         "width": 151,
-        "x": 570.72,
-        "y": 429
+        "x": 580.72,
+        "y": 439
       },
       {
         "children": null,
@@ -547,8 +547,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.ellipse",
         "width": 151,
-        "x": 641.72,
-        "y": 466
+        "x": 651.72,
+        "y": 476
       },
       {
         "children": null,
@@ -579,8 +579,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.ellipse",
         "width": 151,
-        "x": 702.72,
-        "y": 500
+        "x": 712.72,
+        "y": 510
       },
       {
         "children": [
@@ -649,8 +649,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.rectangle",
         "width": 289,
-        "x": 806.5265895902194,
-        "y": 24.5
+        "x": 816.5265895902194,
+        "y": 34.5
       },
       {
         "children": [
@@ -719,8 +719,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.rectangle",
         "width": 289,
-        "x": 806.0265895902194,
-        "y": 88.5
+        "x": 816.0265895902194,
+        "y": 98.5
       },
       {
         "children": [
@@ -789,8 +789,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.rectangle",
         "width": 289,
-        "x": 805.6600030517577,
-        "y": 154.5
+        "x": 815.6600030517577,
+        "y": 164.5
       },
       {
         "children": [
@@ -859,8 +859,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.rectangle",
         "width": 289.0168264712029,
-        "x": 1131.9313642211048,
-        "y": 26.661057223232007
+        "x": 1141.9313642211048,
+        "y": 36.66105722323201
       },
       {
         "children": [
@@ -929,8 +929,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.rectangle",
         "width": 289.0168264712029,
-        "x": 1131.9313642547336,
-        "y": 154.91254383484807
+        "x": 1141.9313642547336,
+        "y": 164.91254383484807
       },
       {
         "children": [
@@ -999,8 +999,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.rectangle",
         "width": 289.0168264712029,
-        "x": 1131.9313641778103,
-        "y": 288.8955216810017
+        "x": 1141.9313641778103,
+        "y": 298.8955216810017
       },
       {
         "children": null,
@@ -1026,8 +1026,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.image",
         "width": 289.01682699999986,
-        "x": 1131.9313639999998,
-        "y": 436.855075875794
+        "x": 1141.9313639999998,
+        "y": 446.855075875794
       },
       {
         "children": null,
@@ -1058,8 +1058,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.round_rectangle",
         "width": 641,
-        "x": 5.042576334960813,
-        "y": 745.5
+        "x": 15.042576334960813,
+        "y": 755.5
       },
       {
         "children": null,
@@ -1086,8 +1086,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.svg",
         "width": 118,
-        "x": 72.04257633496081,
-        "y": 787.5
+        "x": 82.04257633496081,
+        "y": 797.5
       },
       {
         "children": null,
@@ -1114,8 +1114,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.svg",
         "width": 143,
-        "x": 253.0425763349608,
-        "y": 782.5
+        "x": 263.0425763349608,
+        "y": 792.5
       },
       {
         "children": null,
@@ -1142,8 +1142,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.svg",
         "width": 97,
-        "x": 500.0425763349608,
-        "y": 775.5
+        "x": 510.0425763349608,
+        "y": 785.5
       },
       {
         "children": null,
@@ -1170,8 +1170,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.svg",
         "width": 246,
-        "x": 304.0425763349608,
-        "y": 922.5
+        "x": 314.0425763349608,
+        "y": 932.5
       },
       {
         "children": null,
@@ -1198,8 +1198,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.svg",
         "width": 4,
-        "x": 129.0425763349608,
-        "y": 928.5
+        "x": 139.0425763349608,
+        "y": 938.5
       },
       {
         "children": null,
@@ -1226,8 +1226,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.svg",
         "width": 132,
-        "x": 63.04257633496081,
-        "y": 1113.5
+        "x": 73.04257633496081,
+        "y": 1123.5
       },
       {
         "children": [
@@ -1308,8 +1308,8 @@
         "rotation": 0,
         "uid": "com.gliffy.shape.basic.basic_v1.default.line",
         "width": 138,
-        "x": 983.9740955,
-        "y": 586.25
+        "x": 993.9740955,
+        "y": 596.25
       }
     ],
     "printModel": {


### PR DESCRIPTION
* Fixes issue with clipping on top-left objects, i.e. when objects have rounded corners or significant line stroke width.
* Compensates by substracting 10px from horizontal and vertical canvas offset.