### PR TITLE
chore: Official Homebrew Formulae adaptation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,14 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       -
         name: Set up Go
         uses: actions/setup-go@v5
+      -
+        name: Update version.go with Git tag and commit SHA
+        run: |
+          sed -i 's/version *= *"[^"]*"/version = "${{ github.ref_name }}"/' cmd/version.go
+          sed -i 's/commit *= *"[^"]*"/commit = "${{ github.sha }}"/' cmd/version.go
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,3 +76,4 @@ brews:
     # Default is 'bin.install "program"'.
     install: |
       bin.install "exconv"
+      bin.install_symlink "#{bin}/exconv" => "excalidraw-converter"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X diagram-converter/cmd.version={{.Version}} -X diagram-converter/cmd.commit={{.Commit}}
+      - -s -w
 archives:
   -
     format_overrides:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ brew install excalidraw-converter
 <details>
   <summary>Latest releases</summary>
 
-If a release is not (yet) available in the official Homebrew Formulae, they can be installed from this tap:
+Use this tap to stay on the latest releases that have not (yet) been added to the official Homebrew Formulae:
 
 ```shell
 brew install sindrel/tap/excalidraw-converter

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ In draw.io, you can import a diagram by simply opening the file from your device
 
 Note that this is [only supported in the online version](https://www.drawio.com/blog/import-gliffy-online) of draw.io, not the desktop app.
 
+## Compatibility with Excalidraw for Obsidian
+Diagrams created using the [Excalidraw for Obsidian plugin](https://github.com/zsviczian/obsidian-excalidraw-plugin) must be exported before conversion, as described [here](https://github.com/sindrel/excalidraw-converter/issues/27#issuecomment-1759964572).
+
 ## Contributing
 See something you'd like to improve? Great! See the [contributing guidelines](CONTRIBUTING.md) for instructions.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,21 @@ Excalidraw Converter ports Excalidraw diagrams to a Gliffy compatible format, wh
 ## Getting started
 
 ### Installation
-#### MacOS with [Homebrew](https://brew.sh/)
+#### MacOS with [Homebrew](https://brew.sh/) (stable)
+```shell
+brew install excalidraw-converter
+```
+
+<details>
+  <summary>Latest releases</summary>
+
+If a release is not (yet) available in the official Homebrew Formulae, they can be installed from this tap:
+
 ```shell
 brew install sindrel/tap/excalidraw-converter
 ```
+</details>
+
 
 #### Installation for other OSes
 Download a compatible binary from the [Releases](https://github.com/sindrel/excalidraw-converter/releases) page.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,10 +21,10 @@ var versionCmd = &cobra.Command{
 	Short: "Output the application version",
 	Long:  `This command provides information about the release version and the Git commit it was built from.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("v%s (%s)\n", version, string(commit[0:7]))
+		fmt.Printf("%s (%s)\n", version, string(commit[0:7]))
 
 		if !noVersionCheck {
-			err := internal.PrintVersionCheck(githubRepoUser, githubRepoName, "v"+version)
+			err := internal.PrintVersionCheck(githubRepoUser, githubRepoName, version)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to check for latest version: %s\n", err)
 				os.Exit(1)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -63,7 +63,7 @@ func PrintVersionCheck(user, repo, version string) error {
 	}
 
 	if !isLatest {
-		fmt.Printf("\nA newer version is available (%s). Go to 'https://github.com/%s/%s/releases' to download the latest version.\n", latest, user, repo)
+		fmt.Printf("\nA newer version is available (%s). Go to 'https://github.com/%s/%s' for instructions on how to install the latest version.\n", latest, user, repo)
 	} else {
 		fmt.Printf("\nYou are using the latest version.\n")
 	}


### PR DESCRIPTION
* Includes changes to make in-app version context work with official Homebrew Formulae builds
* Symlinks `exconv` -> `excalidraw-converter` in homebrew-tap, to make use similar to official Homebrew Formulae installs
* Updates installation instructions
* Adds a paragraph on compatibility with the Excalidraw plugin for Obsidian

Closes #48.