### PR TITLE
fix: Use build vars in release pipeline, fix version lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,6 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
       -
-        name: Update version.go with Git tag and commit SHA
-        run: |
-          sed -i 's/version *= *"[^"]*"/version = "${{ github.ref_name }}"/' cmd/version.go
-          sed -i 's/commit *= *"[^"]*"/commit = "${{ github.sha }}"/' cmd/version.go
-      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w
+      - -s -w -X diagram-converter/cmd.version={{.Version}}
 archives:
   -
     format_overrides:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X diagram-converter/cmd.version={{.Version}}
+      - -s -w -X diagram-converter/cmd.version={{.Version}} -X diagram-converter/cmd.commit={{.Commit}}
 archives:
   -
     format_overrides:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,7 +23,7 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("v%s\n", version)
 		if commit != "" {
-			fmt.Printf("%s\n", commit)
+			fmt.Printf("%s\n", string(commit[0:7]))
 		}
 
 		if !noVersionCheck {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	version        = "dev"
+	commit         = ""
 	githubRepoUser = "sindrel"
 	githubRepoName = "excalidraw-converter"
 	noVersionCheck bool
@@ -18,9 +19,12 @@ var (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Output the application version",
-	Long:  `This command provides information about the release version and the Git commit it was built from.`,
+	Long:  `This command provides information about current and available release(s).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("v%s\n", version)
+		if commit != "" {
+			fmt.Printf("%s\n", commit)
+		}
 
 		if !noVersionCheck {
 			err := internal.PrintVersionCheck(githubRepoUser, githubRepoName, "v"+version)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,7 +10,6 @@ import (
 
 var (
 	version        = "dev"
-	commit         = "nnnnnnn"
 	githubRepoUser = "sindrel"
 	githubRepoName = "excalidraw-converter"
 	noVersionCheck bool
@@ -21,10 +20,10 @@ var versionCmd = &cobra.Command{
 	Short: "Output the application version",
 	Long:  `This command provides information about the release version and the Git commit it was built from.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("%s (%s)\n", version, string(commit[0:7]))
+		fmt.Printf("v%s\n", version)
 
 		if !noVersionCheck {
-			err := internal.PrintVersionCheck(githubRepoUser, githubRepoName, version)
+			err := internal.PrintVersionCheck(githubRepoUser, githubRepoName, "v"+version)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to check for latest version: %s\n", err)
 				os.Exit(1)


### PR DESCRIPTION
Reverts changes to the release pipeline introduced in #49, addressing problems with version lookup. The official Homebrew repo formulae will be updated to use the same mechanism to set the release version.
