### PR TITLE
fix: Excalidraw 'Pressures' value type changed to float

### DIFF
--- a/internal/datastructures/excalidraw.go
+++ b/internal/datastructures/excalidraw.go
@@ -28,7 +28,7 @@ type ExcalidrawSceneElement struct {
 	Link         string                   `json:"link"`
 	Opacity      float64                  `json:"opacity"`
 	Points       [][]float64              `json:"points"`
-	Pressures    []int64                  `json:"pressures"`
+	Pressures    []float64                `json:"pressures"`
 	Roughness    int64                    `json:"roughness"`
 	Roundness    struct {
 		Type int64 `json:"type"`


### PR DESCRIPTION
Fixes problem with converting Excalidraw diagrams with elements that have the `Pressures` attribute set. 

The value in the `ExcalidrawSceneElement` struct was incorrectly declared as []int64, but is now set to []float64.

Reported in issue #59. 