### PR TITLE
fix: Revert to go v1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.24'
         env:
           CGO_ENABLED: 0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module diagram-converter
 
-go 1.25
+go 1.24
 
 require (
 	github.com/spf13/cobra v1.10.1


### PR DESCRIPTION
Revert to v1.24 temporarily in order to mitigate problems with the goreleaser pipeline running go 1.24. Needs further investigation.